### PR TITLE
derive Debug for structs

### DIFF
--- a/soloud/src/audio/ay.rs
+++ b/soloud/src/audio/ay.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use soloud_sys::soloud as ffi;
 
-#[derive(AudioExt)]
+#[derive(Debug, AudioExt)]
 pub struct Ay {
     _inner: *mut ffi::Ay,
 }

--- a/soloud/src/audio/bus.rs
+++ b/soloud/src/audio/bus.rs
@@ -3,7 +3,7 @@ use soloud_sys::soloud as ffi;
 
 pub type Handle = u32;
 
-#[derive(AudioExt)]
+#[derive(Debug, AudioExt)]
 pub struct Bus {
     _inner: *mut ffi::Bus,
 }

--- a/soloud/src/audio/monotone.rs
+++ b/soloud/src/audio/monotone.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use soloud_sys::soloud as ffi;
 use std::path::Path;
 
-#[derive(AudioExt, LoadExt)]
+#[derive(Debug, AudioExt, LoadExt)]
 pub struct Monotone {
     _inner: *mut ffi::Monotone,
 }

--- a/soloud/src/audio/openmpt.rs
+++ b/soloud/src/audio/openmpt.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use soloud_sys::soloud as ffi;
 use std::path::Path;
 
-#[derive(AudioExt, LoadExt)]
+#[derive(Debug, AudioExt, LoadExt)]
 pub struct Openmpt {
     _inner: *mut ffi::Openmpt,
 }

--- a/soloud/src/audio/queue.rs
+++ b/soloud/src/audio/queue.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use soloud_sys::soloud as ffi;
 
-#[derive(AudioExt)]
+#[derive(Debug, AudioExt)]
 pub struct Queue {
     _inner: *mut ffi::Queue,
 }

--- a/soloud/src/audio/speech.rs
+++ b/soloud/src/audio/speech.rs
@@ -13,7 +13,7 @@ pub enum KlattWaveForm {
     Warble,
 }
 
-#[derive(AudioExt)]
+#[derive(Debug, AudioExt)]
 pub struct Speech {
     _inner: *mut ffi::Speech,
 }

--- a/soloud/src/audio/tedsid.rs
+++ b/soloud/src/audio/tedsid.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use soloud_sys::soloud as ffi;
 use std::path::Path;
 
-#[derive(AudioExt, LoadExt)]
+#[derive(Debug, AudioExt, LoadExt)]
 pub struct TedSid {
     _inner: *mut ffi::TedSid,
 }

--- a/soloud/src/audio/vic.rs
+++ b/soloud/src/audio/vic.rs
@@ -18,7 +18,7 @@ pub enum VicRegister {
     MaxRegs,
 }
 
-#[derive(AudioExt)]
+#[derive(Debug, AudioExt)]
 pub struct Vic {
     _inner: *mut ffi::Vic,
 }

--- a/soloud/src/audio/vizsn.rs
+++ b/soloud/src/audio/vizsn.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use soloud_sys::soloud as ffi;
 
-#[derive(AudioExt)]
+#[derive(Debug, AudioExt)]
 pub struct Vizsn {
     _inner: *mut ffi::Vizsn,
 }

--- a/soloud/src/audio/wav.rs
+++ b/soloud/src/audio/wav.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use soloud_sys::soloud as ffi;
 use std::path::Path;
 
-#[derive(AudioExt, LoadExt)]
+#[derive(Debug, AudioExt, LoadExt)]
 pub struct Wav {
     _inner: *mut ffi::Wav,
 }

--- a/soloud/src/audio/wavstream.rs
+++ b/soloud/src/audio/wavstream.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use soloud_sys::soloud as ffi;
 use std::path::Path;
 
-#[derive(AudioExt, LoadExt)]
+#[derive(Debug, AudioExt, LoadExt)]
 pub struct WavStream {
     _inner: *mut ffi::WavStream,
 }
@@ -16,7 +16,9 @@ impl WavStream {
     /// Load a file to memory
     pub fn load_to_mem(&mut self, path: &std::path::Path) -> Result<(), SoloudError> {
         unsafe {
-            let path = path.to_str().ok_or(SoloudError::Internal(SoloudErrorKind::FileLoadFailed))?;
+            let path = path
+                .to_str()
+                .ok_or(SoloudError::Internal(SoloudErrorKind::FileLoadFailed))?;
             let path = std::ffi::CString::new(path)?;
             let ret = ffi::WavStream_loadToMem(self._inner, path.as_ptr());
             if ret != 0 {

--- a/soloud/src/effects.rs
+++ b/soloud/src/effects.rs
@@ -1,6 +1,7 @@
 use soloud_sys::soloud as ffi;
 use std::os::raw::*;
 
+#[derive(Debug)]
 pub struct AudioSourceInstance3dData {
     _inner: *mut ffi::AudioSourceInstance3dData,
 }
@@ -9,9 +10,7 @@ impl AudioSourceInstance3dData {
     /// Instantiante a new AudioSourceInstance3dData
     pub fn new(engine: &crate::Soloud) -> Self {
         unsafe {
-            let ptr = ffi::AudioSourceInstance3dData_new(
-                engine.inner()
-            );
+            let ptr = ffi::AudioSourceInstance3dData_new(engine.inner());
             assert!(!ptr.is_null());
             AudioSourceInstance3dData { _inner: ptr }
         }
@@ -29,6 +28,7 @@ impl Drop for AudioSourceInstance3dData {
     }
 }
 
+#[derive(Debug)]
 /// Audio Collider struct
 pub struct AudioCollider {
     _inner: ffi::AudioCollider,
@@ -87,11 +87,7 @@ impl AudioCollider {
                     arg4: *mut c_void,
                 ) -> f32,
             > = Some(shim);
-            ffi::AudioCollider_set_handler(
-                self._inner,
-                callback,
-                data,
-            );
+            ffi::AudioCollider_set_handler(self._inner, callback, data);
         }
     }
 
@@ -110,6 +106,7 @@ impl Drop for AudioCollider {
 }
 
 /// Audio Attenuator struct
+#[derive(Debug)]
 pub struct AudioAttenuator {
     _inner: ffi::AudioAttenuator,
 }
@@ -159,11 +156,7 @@ impl AudioAttenuator {
                     data: *mut c_void,
                 ) -> f32,
             > = Some(shim);
-            ffi::AudioAttenuator_set_handler(
-                self._inner,
-                callback,
-                data,
-            );
+            ffi::AudioAttenuator_set_handler(self._inner, callback, data);
         }
     }
 

--- a/soloud/src/filter/bass.rs
+++ b/soloud/src/filter/bass.rs
@@ -8,7 +8,7 @@ pub enum BassBoostFilterAttr {
     Boost = 1,
 }
 
-#[derive(FilterExt)]
+#[derive(Debug, FilterExt)]
 pub struct BassboostFilter {
     _inner: *mut soloud_sys::soloud::BassboostFilter,
 }

--- a/soloud/src/filter/biquad.rs
+++ b/soloud/src/filter/biquad.rs
@@ -18,7 +18,7 @@ pub enum BiquadResonantFilterType {
     BandPass,
 }
 
-#[derive(FilterExt)]
+#[derive(Debug, FilterExt)]
 pub struct BiquadResonantFilter {
     _inner: *mut soloud_sys::soloud::BiquadResonantFilter,
 }

--- a/soloud/src/filter/dc.rs
+++ b/soloud/src/filter/dc.rs
@@ -1,7 +1,7 @@
 use super::ParamType;
 use crate::prelude::*;
 
-#[derive(FilterExt)]
+#[derive(Debug, FilterExt)]
 pub struct DCRemovalFilter {
     _inner: *mut soloud_sys::soloud::DCRemovalFilter,
 }

--- a/soloud/src/filter/echo.rs
+++ b/soloud/src/filter/echo.rs
@@ -10,7 +10,7 @@ pub enum EchoFilterAttr {
     Filter,
 }
 
-#[derive(FilterExt)]
+#[derive(Debug, FilterExt)]
 pub struct EchoFilter {
     _inner: *mut soloud_sys::soloud::EchoFilter,
 }

--- a/soloud/src/filter/fft.rs
+++ b/soloud/src/filter/fft.rs
@@ -1,7 +1,7 @@
 use super::ParamType;
 use crate::prelude::*;
 
-#[derive(FilterExt)]
+#[derive(Debug, FilterExt)]
 pub struct FFTFilter {
     _inner: *mut soloud_sys::soloud::FFTFilter,
 }

--- a/soloud/src/filter/flanger.rs
+++ b/soloud/src/filter/flanger.rs
@@ -9,7 +9,7 @@ pub enum FlangerFilterAttr {
     Freq = 2,
 }
 
-#[derive(FilterExt)]
+#[derive(Debug, FilterExt)]
 pub struct FlangerFilter {
     _inner: *mut soloud_sys::soloud::FlangerFilter,
 }

--- a/soloud/src/filter/freeverb.rs
+++ b/soloud/src/filter/freeverb.rs
@@ -1,7 +1,7 @@
 use super::ParamType;
 use crate::prelude::*;
 
-#[derive(FilterExt)]
+#[derive(Debug, FilterExt)]
 pub struct FreeverbFilter {
     _inner: *mut soloud_sys::soloud::FreeverbFilter,
 }

--- a/soloud/src/filter/lofi.rs
+++ b/soloud/src/filter/lofi.rs
@@ -9,7 +9,7 @@ pub enum LofiFilterAttr {
     BitDepth = 2,
 }
 
-#[derive(FilterExt)]
+#[derive(Debug, FilterExt)]
 pub struct LofiFilter {
     _inner: *mut soloud_sys::soloud::LofiFilter,
 }

--- a/soloud/src/filter/robotize.rs
+++ b/soloud/src/filter/robotize.rs
@@ -9,7 +9,7 @@ pub enum RobotizeFilterAttr {
     Wave = 2,
 }
 
-#[derive(FilterExt)]
+#[derive(Debug, FilterExt)]
 pub struct RobotizeFilter {
     _inner: *mut soloud_sys::soloud::RobotizeFilter,
 }

--- a/soloud/src/filter/waveshaper.rs
+++ b/soloud/src/filter/waveshaper.rs
@@ -8,7 +8,7 @@ pub enum WaveShaperFilterAttr {
     Amount = 1,
 }
 
-#[derive(FilterExt)]
+#[derive(Debug, FilterExt)]
 pub struct WaveShaperFilter {
     _inner: *mut soloud_sys::soloud::WaveShaperFilter,
 }

--- a/soloud/src/lib.rs
+++ b/soloud/src/lib.rs
@@ -133,6 +133,7 @@ use soloud_sys::soloud as ffi;
 
 pub type Handle = u32;
 
+#[derive(Debug)]
 pub struct Soloud {
     _inner: *mut ffi::Soloud,
 }
@@ -184,8 +185,14 @@ impl Soloud {
     ) -> Result<(), SoloudError> {
         assert!(!self._inner.is_null());
         unsafe {
-            let ret =
-                ffi::Soloud_initEx(self._inner, flags.bits() as u32, 0, samplerate, buf_size, channels);
+            let ret = ffi::Soloud_initEx(
+                self._inner,
+                flags.bits() as u32,
+                0,
+                samplerate,
+                buf_size,
+                channels,
+            );
             if ret != 0 {
                 Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
             } else {


### PR DESCRIPTION
So that their owners can just use `#[derive(Debug)]`!

This PR contains some format changes, but I _think_ I'm using `rustfmt` with default settings.

Thanks :)