### PR TITLE
refactor using ffi_call!

### DIFF
--- a/soloud/src/audio/monotone.rs
+++ b/soloud/src/audio/monotone.rs
@@ -10,14 +10,7 @@ pub struct Monotone {
 impl Monotone {
     /// Set monotone parameters
     pub fn set_params(&mut self, hardware_channel: i32) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = ffi::Monotone_setParams(self._inner, hardware_channel);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Monotone_setParams(self._inner, hardware_channel))
     }
 
     /// Set monotone parameters specifying the wave form
@@ -26,13 +19,10 @@ impl Monotone {
         hardware_channel: i32,
         wave_form: WaveForm,
     ) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = ffi::Monotone_setParamsEx(self._inner, hardware_channel, wave_form as i32);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Monotone_setParamsEx(
+            self._inner,
+            hardware_channel,
+            wave_form as i32
+        ))
     }
 }

--- a/soloud/src/audio/queue.rs
+++ b/soloud/src/audio/queue.rs
@@ -9,14 +9,7 @@ pub struct Queue {
 impl Queue {
     /// Play audio
     pub fn play<T: AudioExt>(&self, sound: &T) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = ffi::Queue_play(self._inner, sound.inner());
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Queue_play(self._inner, sound.inner()))
     }
 
     /// Get queue count
@@ -34,37 +27,19 @@ impl Queue {
         &mut self,
         sound: &AS,
     ) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = ffi::Queue_setParamsFromAudioSource(self._inner, sound.inner());
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Queue_setParamsFromAudioSource(
+            self._inner,
+            sound.inner()
+        ))
     }
 
     /// Set params of the queue
     pub fn set_params(&mut self, samplerate: f32) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = ffi::Queue_setParams(self._inner, samplerate);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Queue_setParams(self._inner, samplerate))
     }
 
     /// Set params of the queue adding channels
     pub fn set_params_ex(&mut self, samplerate: f32, channels: u32) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = ffi::Queue_setParamsEx(self._inner, samplerate, channels);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Queue_setParamsEx(self._inner, samplerate, channels))
     }
 }

--- a/soloud/src/audio/sfxr.rs
+++ b/soloud/src/audio/sfxr.rs
@@ -21,14 +21,7 @@ pub struct Sfxr {
 impl Sfxr {
     /// Load preset
     pub fn load_preset(&mut self, preset: SfxrPreset, rand_seed: i32) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = ffi::Sfxr_loadPreset(self._inner, preset as i32, rand_seed);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Sfxr_loadPreset(self._inner, preset as i32, rand_seed))
     }
 
     /// Resets parameters
@@ -38,33 +31,21 @@ impl Sfxr {
 
     /// Load parameters from a file
     pub fn load_params(&mut self, path: &std::path::Path) -> Result<(), SoloudError> {
-        unsafe {
-            let path = path.to_str().ok_or(SoloudError::Internal(SoloudErrorKind::FileLoadFailed))?;
-            let path = std::ffi::CString::new(path)?;
-            let ret = ffi::Sfxr_loadParams(self._inner, path.as_ptr());
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        let path = path
+            .to_str()
+            .ok_or(SoloudError::Internal(SoloudErrorKind::FileLoadFailed))?;
+        let path = std::ffi::CString::new(path)?;
+        ffi_call!(ffi::Sfxr_loadParams(self._inner, path.as_ptr()))
     }
 
     /// Load parameters from memory
     pub fn load_params_mem(&mut self, params: &[u8]) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = ffi::Sfxr_loadParamsMemEx(
-                self._inner,
-                params.as_ptr() as *mut _,
-                params.len() as u32,
-                1,
-                1,
-            );
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Sfxr_loadParamsMemEx(
+            self._inner,
+            params.as_ptr() as *mut _,
+            params.len() as u32,
+            1,
+            1,
+        ))
     }
 }

--- a/soloud/src/audio/speech.rs
+++ b/soloud/src/audio/speech.rs
@@ -21,27 +21,13 @@ pub struct Speech {
 impl Speech {
     /// set speech text
     pub fn set_text(&mut self, txt: &str) -> Result<(), SoloudError> {
-        unsafe {
-            let txt = std::ffi::CString::new(txt)?;
-            let ret = ffi::Speech_setText(self._inner, txt.as_ptr());
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        let txt = std::ffi::CString::new(txt)?;
+        ffi_call!(ffi::Speech_setText(self._inner, txt.as_ptr()))
     }
 
     /// Set speech params
     pub fn set_params(&mut self) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = ffi::Speech_setParams(self._inner);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Speech_setParams(self._inner))
     }
 
     /// Set speech params
@@ -52,19 +38,12 @@ impl Speech {
         base_declination: f32,
         base_waveform: KlattWaveForm,
     ) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = ffi::Speech_setParamsEx(
-                self._inner,
-                base_freq,
-                base_speed,
-                base_declination,
-                base_waveform as i32,
-            );
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Speech_setParamsEx(
+            self._inner,
+            base_freq,
+            base_speed,
+            base_declination,
+            base_waveform as i32,
+        ))
     }
 }

--- a/soloud/src/audio/wav.rs
+++ b/soloud/src/audio/wav.rs
@@ -12,15 +12,11 @@ impl Wav {
     /// # Safety
     /// The data must be valid
     pub unsafe fn load_raw_wav_8(&mut self, data: &[u8]) -> Result<(), SoloudError> {
-        unsafe {
-            let ret =
-                ffi::Wav_loadRawWave8(self._inner, data.as_ptr() as *mut _, data.len() as u32);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Wav_loadRawWave8(
+            self._inner,
+            data.as_ptr() as *mut _,
+            data.len() as u32
+        ))
     }
 
     /// Load raw wav data of precise bits
@@ -32,35 +28,24 @@ impl Wav {
         samplerate: f32,
         channels: u32,
     ) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = ffi::Wav_loadRawWave8Ex(
-                self._inner,
-                data.as_ptr() as *mut _,
-                data.len() as u32,
-                samplerate,
-                channels,
-            );
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Wav_loadRawWave8Ex(
+            self._inner,
+            data.as_ptr() as *mut _,
+            data.len() as u32,
+            samplerate,
+            channels,
+        ))
     }
 
     /// Load raw wav data of precise bits
     /// # Safety
     /// The data must be valid
     pub unsafe fn load_raw_wav_16(&mut self, data: &[i16]) -> Result<(), SoloudError> {
-        unsafe {
-            let ret =
-                ffi::Wav_loadRawWave16(self._inner, data.as_ptr() as *mut _, data.len() as u32);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Wav_loadRawWave16(
+            self._inner,
+            data.as_ptr() as *mut _,
+            data.len() as u32
+        ))
     }
 
     /// Load raw wav data of precise bits
@@ -72,34 +57,24 @@ impl Wav {
         samplerate: f32,
         channels: u32,
     ) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = ffi::Wav_loadRawWave16Ex(
-                self._inner,
-                data.as_ptr() as *mut _,
-                data.len() as u32,
-                samplerate,
-                channels,
-            );
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Wav_loadRawWave16Ex(
+            self._inner,
+            data.as_ptr() as *mut _,
+            data.len() as u32,
+            samplerate,
+            channels,
+        ))
     }
 
     /// Load raw wav data of precise bits
     /// # Safety
     /// The data must be valid
     pub unsafe fn load_raw_wav(&mut self, data: &[f32]) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = ffi::Wav_loadRawWave(self._inner, data.as_ptr() as *mut _, data.len() as u32);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Wav_loadRawWave(
+            self._inner,
+            data.as_ptr() as *mut _,
+            data.len() as u32
+        ))
     }
 
     /// Load raw wav data of precise bits
@@ -113,22 +88,15 @@ impl Wav {
         copy: bool,
         take_ownership: bool,
     ) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = ffi::Wav_loadRawWaveEx(
-                self._inner,
-                data.as_ptr() as *mut _,
-                data.len() as u32,
-                samplerate,
-                channels,
-                copy as i32,
-                take_ownership as i32,
-            );
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Wav_loadRawWaveEx(
+            self._inner,
+            data.as_ptr() as *mut _,
+            data.len() as u32,
+            samplerate,
+            channels,
+            copy as i32,
+            take_ownership as i32,
+        ))
     }
 
     /// Get the length of the Wav object

--- a/soloud/src/audio/wavstream.rs
+++ b/soloud/src/audio/wavstream.rs
@@ -15,17 +15,10 @@ impl WavStream {
 
     /// Load a file to memory
     pub fn load_to_mem(&mut self, path: &std::path::Path) -> Result<(), SoloudError> {
-        unsafe {
-            let path = path
-                .to_str()
-                .ok_or(SoloudError::Internal(SoloudErrorKind::FileLoadFailed))?;
-            let path = std::ffi::CString::new(path)?;
-            let ret = ffi::WavStream_loadToMem(self._inner, path.as_ptr());
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        let path = path
+            .to_str()
+            .ok_or(SoloudError::Internal(SoloudErrorKind::FileLoadFailed))?;
+        let path = std::ffi::CString::new(path)?;
+        ffi_call!(ffi::WavStream_loadToMem(self._inner, path.as_ptr()))
     }
 }

--- a/soloud/src/filter/bass.rs
+++ b/soloud/src/filter/bass.rs
@@ -16,13 +16,9 @@ pub struct BassboostFilter {
 impl BassboostFilter {
     /// Set filter params
     pub fn set_params(&mut self, delay: f32) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = soloud_sys::soloud::BassboostFilter_setParams(self._inner, delay);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(soloud_sys::soloud::BassboostFilter_setParams(
+            self._inner,
+            delay
+        ))
     }
 }

--- a/soloud/src/filter/biquad.rs
+++ b/soloud/src/filter/biquad.rs
@@ -31,18 +31,11 @@ impl BiquadResonantFilter {
         frequency: f32,
         resonance: f32,
     ) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = soloud_sys::soloud::BiquadResonantFilter_setParams(
-                self._inner,
-                filter_type as i32,
-                frequency,
-                resonance,
-            );
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(soloud_sys::soloud::BiquadResonantFilter_setParams(
+            self._inner,
+            filter_type as i32,
+            frequency,
+            resonance,
+        ))
     }
 }

--- a/soloud/src/filter/dc.rs
+++ b/soloud/src/filter/dc.rs
@@ -9,25 +9,14 @@ pub struct DCRemovalFilter {
 impl DCRemovalFilter {
     /// Set filter params
     pub fn set_params(&mut self) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = soloud_sys::soloud::DCRemovalFilter_setParams(self._inner);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(soloud_sys::soloud::DCRemovalFilter_setParams(self._inner))
     }
 
     /// Set filter params with extra args
     pub fn set_params_ex(&mut self, delay: f32) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = soloud_sys::soloud::DCRemovalFilter_setParamsEx(self._inner, delay);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(soloud_sys::soloud::DCRemovalFilter_setParamsEx(
+            self._inner,
+            delay
+        ))
     }
 }

--- a/soloud/src/filter/echo.rs
+++ b/soloud/src/filter/echo.rs
@@ -18,14 +18,7 @@ pub struct EchoFilter {
 impl EchoFilter {
     /// Set filter params
     pub fn set_params(&mut self, delay: f32) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = soloud_sys::soloud::EchoFilter_setParams(self._inner, delay);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(soloud_sys::soloud::EchoFilter_setParams(self._inner, delay))
     }
 
     /// Set filter params with extra args
@@ -35,13 +28,11 @@ impl EchoFilter {
         decay: f32,
         filter: f32,
     ) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = soloud_sys::soloud::EchoFilter_setParamsEx(self._inner, delay, decay, filter);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(soloud_sys::soloud::EchoFilter_setParamsEx(
+            self._inner,
+            delay,
+            decay,
+            filter
+        ))
     }
 }

--- a/soloud/src/filter/flanger.rs
+++ b/soloud/src/filter/flanger.rs
@@ -17,13 +17,10 @@ pub struct FlangerFilter {
 impl FlangerFilter {
     /// Set filter params
     pub fn set_params(&mut self, delay: f32, freq: f32) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = soloud_sys::soloud::FlangerFilter_setParams(self._inner, delay, freq);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(soloud_sys::soloud::FlangerFilter_setParams(
+            self._inner,
+            delay,
+            freq
+        ))
     }
 }

--- a/soloud/src/filter/freeverb.rs
+++ b/soloud/src/filter/freeverb.rs
@@ -15,19 +15,12 @@ impl FreeverbFilter {
         damp: f32,
         width: f32,
     ) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = soloud_sys::soloud::FreeverbFilter_setParams(
-                self._inner,
-                mode,
-                room_size,
-                damp,
-                width,
-            );
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(soloud_sys::soloud::FreeverbFilter_setParams(
+            self._inner,
+            mode,
+            room_size,
+            damp,
+            width,
+        ))
     }
 }

--- a/soloud/src/filter/lofi.rs
+++ b/soloud/src/filter/lofi.rs
@@ -17,13 +17,10 @@ pub struct LofiFilter {
 impl LofiFilter {
     /// Set filter params
     pub fn set_params(&mut self, samplerate: f32, bit_depth: f32) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = soloud_sys::soloud::LofiFilter_setParams(self._inner, samplerate, bit_depth);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(soloud_sys::soloud::LofiFilter_setParams(
+            self._inner,
+            samplerate,
+            bit_depth
+        ))
     }
 }

--- a/soloud/src/filter/waveshaper.rs
+++ b/soloud/src/filter/waveshaper.rs
@@ -16,13 +16,9 @@ pub struct WaveShaperFilter {
 impl WaveShaperFilter {
     /// Set filter params
     pub fn set_params(&mut self, amount: f32) -> Result<(), SoloudError> {
-        unsafe {
-            let ret = soloud_sys::soloud::WaveShaperFilter_setParams(self._inner, amount);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(soloud_sys::soloud::WaveShaperFilter_setParams(
+            self._inner,
+            amount
+        ))
     }
 }

--- a/soloud/src/lib.rs
+++ b/soloud/src/lib.rs
@@ -114,6 +114,18 @@
 #![allow(unused_unsafe)]
 #![allow(non_upper_case_globals)]
 
+/// FFI function call with error handling
+///
+/// NOTE: It has to be defined _before_ declaring sub modules.
+macro_rules! ffi_call {
+    ($s:expr) => {
+        match unsafe { $s } {
+            0 => Ok(()),
+            code => Err(SoloudError::Internal(SoloudErrorKind::from_i32(code))),
+        }
+    };
+}
+
 pub mod audio;
 pub mod filter;
 pub mod prelude;
@@ -166,14 +178,7 @@ impl Soloud {
     /// initialize an uninitialized instance of Soloud
     pub fn init(&mut self) -> Result<(), SoloudError> {
         assert!(!self._inner.is_null());
-        unsafe {
-            let ret = ffi::Soloud_init(self._inner);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Soloud_init(self._inner))
     }
 
     /// Creates a default initialized instance of soloud
@@ -192,21 +197,14 @@ impl Soloud {
         channels: u32,
     ) -> Result<(), SoloudError> {
         assert!(!self._inner.is_null());
-        unsafe {
-            let ret = ffi::Soloud_initEx(
-                self._inner,
-                flags.bits() as u32,
-                0,
-                samplerate,
-                buf_size,
-                channels,
-            );
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Soloud_initEx(
+            self._inner,
+            flags.bits() as u32,
+            0,
+            samplerate,
+            buf_size,
+            channels,
+        ))
     }
 
     /// Creates a default initialized instance of soloud
@@ -217,11 +215,8 @@ impl Soloud {
         channels: u32,
     ) -> Result<Self, SoloudError> {
         let mut temp = unsafe { Soloud::default_uninit().assume_init() };
-        if let Err(val) = temp.init_ex(flags, samplerate, buf_size, channels) {
-            Err(val)
-        } else {
-            Ok(temp)
-        }
+        temp.init_ex(flags, samplerate, buf_size, channels)?;
+        Ok(temp)
     }
 
     /// Gets the current version of the Soloud library
@@ -267,30 +262,29 @@ impl Soloud {
         z: f32,
     ) -> Result<(), SoloudError> {
         assert!(!self._inner.is_null());
-        unsafe {
-            let ret = ffi::Soloud_setSpeakerPosition(self._inner, channel, x, y, z);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Soloud_setSpeakerPosition(
+            self._inner,
+            channel,
+            x,
+            y,
+            z
+        ))
     }
 
     /// Get the speaker position
     pub fn speaker_position(&self, channel: u32) -> Result<(f32, f32, f32), SoloudError> {
         assert!(!self._inner.is_null());
-        unsafe {
-            let mut x = 0.0;
-            let mut y = 0.0;
-            let mut z = 0.0;
-            let ret = ffi::Soloud_getSpeakerPosition(self._inner, channel, &mut x, &mut y, &mut z);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok((x, y, z))
-            }
-        }
+        let mut x = 0.0;
+        let mut y = 0.0;
+        let mut z = 0.0;
+        ffi_call!(ffi::Soloud_getSpeakerPosition(
+            self._inner,
+            channel,
+            &mut x,
+            &mut y,
+            &mut z
+        ))?;
+        Ok((x, y, z))
     }
 
     /// Play audio with extra args
@@ -444,14 +438,7 @@ impl Soloud {
     /// Seek in seconds
     pub fn seek(&self, voice_handle: Handle, seconds: f64) -> Result<(), SoloudError> {
         assert!(!self._inner.is_null());
-        unsafe {
-            let ret = ffi::Soloud_seek(self._inner, voice_handle.0, seconds);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Soloud_seek(self._inner, voice_handle.0, seconds))
     }
 
     /// Stop audio by handle
@@ -634,14 +621,7 @@ impl Soloud {
     /// Set max active voice count
     pub fn set_max_active_voice_count(&mut self, count: u32) -> Result<(), SoloudError> {
         assert!(!self._inner.is_null());
-        unsafe {
-            let ret = ffi::Soloud_setMaxActiveVoiceCount(self._inner, count);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Soloud_setMaxActiveVoiceCount(self._inner, count))
     }
 
     /// Set inaudible behaviour
@@ -688,14 +668,11 @@ impl Soloud {
         speed: f32,
     ) -> Result<(), SoloudError> {
         assert!(!self._inner.is_null());
-        unsafe {
-            let ret = ffi::Soloud_setRelativePlaySpeed(self._inner, voice_handle.0, speed);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Soloud_setRelativePlaySpeed(
+            self._inner,
+            voice_handle.0,
+            speed
+        ))
     }
 
     /// Set whether an audio source has protect voice
@@ -861,14 +838,10 @@ impl Soloud {
     /// Destroy a voice group
     pub fn destroy_voice_group(&self, voice_group_handle: Handle) -> Result<(), SoloudError> {
         assert!(!self._inner.is_null());
-        unsafe {
-            let ret = ffi::Soloud_destroyVoiceGroup(self._inner, voice_group_handle.0);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Soloud_destroyVoiceGroup(
+            self._inner,
+            voice_group_handle.0
+        ))
     }
 
     /// Add a voice handle to a voice group
@@ -878,15 +851,11 @@ impl Soloud {
         voice_handle: Handle,
     ) -> Result<(), SoloudError> {
         assert!(!self._inner.is_null());
-        unsafe {
-            let ret =
-                ffi::Soloud_addVoiceToGroup(self._inner, voice_group_handle.0, voice_handle.0);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Soloud_addVoiceToGroup(
+            self._inner,
+            voice_group_handle.0,
+            voice_handle.0
+        ))
     }
 
     /// Check whether a handle is of a voice group
@@ -910,14 +879,7 @@ impl Soloud {
     /// Set 3D sound speed
     pub fn set_3d_sound_speed(&self, speed: f32) -> Result<(), SoloudError> {
         assert!(!self._inner.is_null());
-        unsafe {
-            let ret = ffi::Soloud_set3dSoundSpeed(self._inner, speed);
-            if ret != 0 {
-                Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-            } else {
-                Ok(())
-            }
-        }
+        ffi_call!(ffi::Soloud_set3dSoundSpeed(self._inner, speed))
     }
 
     /// Get 3d sound speed


### PR DESCRIPTION
This PR tries to improve the readability by batching error handling boilerplates into a `ffi_call` marco:

```rust
macro_rules! ffi_call {
    ($s:expr) => {
        match unsafe { $s } {
            0 => Ok(()),
            code => Err(SoloudError::Internal(SoloudErrorKind::from_i32(code))),
        }
    };
}
```

Another approach would be `#[inline] fn`.

* `ffi_call!` contains `unsafe { .. }` and short
* `#[inline] fn` is natural Rust and would be (a little bit) better for compilation time

Edit: comparison example:

```rust
impl Monotone {
    pub fn set_params(&mut self, hardware_channel: i32) -> Result<(), SoloudError> {
        ffi_call!(ffi::Monotone_setParams(self._inner, hardware_channel))
    }

    pub fn set_params(&mut self, hardware_channel: i32) -> Result<(), SoloudError> {
        unsafe {
            let ret = ffi::Monotone_setParams(self._inner, hardware_channel);
            crate::try_ffi(ret)
        }
    }
}
```

Which would you prefer? Another `#[inline] fn` PR would also be pretty easy (like 10 minutes). Thanks.