### PR TITLE
fix #9

### DIFF
--- a/soloud-derive/src/audio.rs
+++ b/soloud-derive/src/audio.rs
@@ -77,56 +77,56 @@ pub fn impl_audio_trait(ast: &DeriveInput) -> TokenStream {
             }
 
             fn set_volume(&mut self, volume: f32) {
-                
+
                 unsafe {
                     soloud_sys::soloud::#setVolume(self._inner, volume)
                 }
             }
 
             fn set_looping(&mut self, flag: bool) {
-                
+
                 unsafe {
                     soloud_sys::soloud::#setLooping(self._inner, flag as i32)
                 }
             }
 
             fn set_auto_stop(&mut self, flag: bool) {
-                
+
                 unsafe {
                     soloud_sys::soloud::#setAutoStop(self._inner, flag as i32)
                 }
             }
 
             fn set_3d_min_max_distance(&mut self, min_distance: f32, max_distance: f32) {
-                
+
                 unsafe {
                     soloud_sys::soloud::#set3dMinMaxDistance(self._inner, min_distance, max_distance)
                 }
             }
 
             fn set_3d_attenuation(&mut self, model: AttenuationModel, rolloff_factor: f32) {
-                
+
                 unsafe {
                     soloud_sys::soloud::#set3dAttenuation(self._inner, model as u32, rolloff_factor)
                 }
             }
 
             fn set_3d_doppler_factor(&mut self, doppler_factor: f32) {
-                
+
                 unsafe {
                     soloud_sys::soloud::#set3dDopplerFactor(self._inner, doppler_factor)
                 }
             }
 
             fn set_3d_listener_relative(&mut self, flag: bool) {
-                
+
                 unsafe {
                     soloud_sys::soloud::#set3dListenerRelative(self._inner, flag as i32)
                 }
             }
 
             fn set_3d_distance_delay(&mut self, distance_delay: i32) {
-                
+
                 unsafe {
                     soloud_sys::soloud::#set3dDistanceDelay(self._inner, distance_delay)
                 }
@@ -137,7 +137,7 @@ pub fn impl_audio_trait(ast: &DeriveInput) -> TokenStream {
             //         Some(v) => unsafe { v.inner() },
             //         None => std::ptr::null_mut(),
             //     };
-                
+
             //     unsafe {
             //         soloud_sys::soloud::#set3dCollider(self._inner, &mut collider as *mut *mut _)
             //     }
@@ -148,28 +148,28 @@ pub fn impl_audio_trait(ast: &DeriveInput) -> TokenStream {
             //         Some(v) => unsafe { v.inner() },
             //         None => std::ptr::null_mut(),
             //     };
-                
+
             //     unsafe {
             //         soloud_sys::soloud::#set3dAttenuator(self._inner, &mut attenuator as *mut *mut _)
             //     }
             // }
 
             fn set_inaudible_behavior(&mut self, must_tick: bool, kill: bool) {
-                
+
                 unsafe {
                     soloud_sys::soloud::#setInaudibleBehavior(self._inner, must_tick as i32, kill as i32)
                 }
             }
 
             fn set_loop_point(&mut self, loop_point: f64) {
-                
+
                 unsafe {
                     soloud_sys::soloud::#setLoopPoint(self._inner, loop_point)
                 }
             }
 
             fn loop_point(&self) -> f64 {
-                
+
                 unsafe {
                     soloud_sys::soloud::#getLoopPoint(self._inner)
                 }
@@ -180,14 +180,14 @@ pub fn impl_audio_trait(ast: &DeriveInput) -> TokenStream {
                     Some(v) => unsafe { v.inner() },
                     None => std::ptr::null_mut(),
                 };
-                
+
                 unsafe {
                     soloud_sys::soloud::#setFilter(self._inner, filter_id, filter)
                 }
             }
 
             fn stop(&mut self) {
-                
+
                 unsafe {
                     soloud_sys::soloud::#stop(self._inner)
                 }

--- a/soloud-derive/src/load.rs
+++ b/soloud-derive/src/load.rs
@@ -17,7 +17,6 @@ pub fn impl_load_trait(ast: &DeriveInput) -> TokenStream {
     let gen = quote! {
         unsafe impl LoadExt for #name {
             fn load<P: AsRef<Path>>(&mut self, path: P) -> Result<(), SoloudError> {
-                
                 unsafe {
                     let path = std::ffi::CString::new(path.as_ref().to_str().ok_or(SoloudError::Internal(SoloudErrorKind::FileLoadFailed))?)?;
                     let ret = soloud_sys::soloud::#load(self._inner, path.as_ref().as_ptr());
@@ -29,20 +28,7 @@ pub fn impl_load_trait(ast: &DeriveInput) -> TokenStream {
                 }
             }
 
-            fn load_mem(&mut self, data: &[u8]) -> Result<(), SoloudError> {
-                
-                unsafe {
-                    let ret = soloud_sys::soloud::#loadMemEx(self._inner, data.as_ptr(), data.len() as u32, 0, 0);
-                    if ret != 0 {
-                        Err(SoloudError::Internal(SoloudErrorKind::from_i32(ret)))
-                    } else {
-                        Ok(())
-                    }
-                }
-            }
-
-            unsafe fn load_mem_ex(&mut self, data: &[u8], copy: bool, take_ownership: bool) -> Result<(), SoloudError> {
-                
+            unsafe fn _load_mem_ex(&mut self, data: &[u8], copy: bool, take_ownership: bool) -> Result<(), SoloudError> {
                 unsafe {
                     let ret = soloud_sys::soloud::#loadMemEx(self._inner, data.as_ptr(), data.len() as u32, copy as i32, take_ownership as i32);
                     if ret != 0 {

--- a/soloud/examples/include_bytes.rs
+++ b/soloud/examples/include_bytes.rs
@@ -1,8 +1,12 @@
 fn main() {
-    use soloud::*;
-    let sl = Soloud::default().unwrap();
-    let mut wav = audio::Wav::default();
-    // wav.load_mem(include_bytes!("../audio.mp3")).unwrap();
+    eprintln!(
+        "You have to add `audio.mp3` to `soloud` directory  and modify this example to run it!!"
+    );
+    // use soloud::*;
+    // let sl = Soloud::default().unwrap();
+    // let mut wav = audio::Wav::default();
+    // // Use weak reference because we know `'static &[u8]` lives longer than `Soloud`
+    // wav.load_mem_weak(include_bytes!("../audio.mp3")).unwrap();
     // sl.play(&wav);
     // while sl.voice_count() > 0 {
     //     std::thread::sleep(std::time::Duration::from_millis(100));

--- a/soloud/examples/load_mem.rs
+++ b/soloud/examples/load_mem.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let bytes = std::fs::read("sample.wav")?;
 
-    wav.load_mem(&bytes)?;
+    wav.load_mem(bytes)?;
 
     sl.play(&wav);
     while sl.voice_count() > 0 {

--- a/soloud/src/lib.rs
+++ b/soloud/src/lib.rs
@@ -110,11 +110,11 @@
 //! soloud = { version = "0.3", default-features = false, features = ["alsa"] }
 //! ```
 //! This also assumes that those libraries headers are in your include path where CMake can find them, otherwise you can set it via the command line (posix):
-//! ```ignore
+//! ```sh
 //! $ export CXXFLAGS="-I /path/to/include"
 //! ```
 //! or for Windows:
-//! ```ignore
+//! ```sh
 //! $ set CXXFLAGS="-I C:\\path\\to\\include"
 //! ```
 //! ### Supported backends:
@@ -131,7 +131,6 @@
 //! - opensles
 //! - coreaudio
 //! - jack
-
 
 #![allow(unused_unsafe)]
 #![allow(non_upper_case_globals)]
@@ -255,7 +254,7 @@ impl Soloud {
     /// Gets the backend name
     pub fn backend_string(&self) -> String {
         assert!(!self._inner.is_null());
-        unsafe { 
+        unsafe {
             let ptr = ffi::Soloud_getBackendString(self._inner);
             assert!(!ptr.is_null());
             std::ffi::CStr::from_ptr(ptr).to_string_lossy().to_string()

--- a/soloud/src/prelude.rs
+++ b/soloud/src/prelude.rs
@@ -1,8 +1,9 @@
 // pub use crate::effects::*;
+use std::borrow::Cow;
 use std::convert::From;
 use std::os::raw::*;
-use std::{fmt, io};
 use std::path::Path;
+use std::{fmt, io};
 
 #[derive(Debug)]
 pub enum SoloudError {
@@ -151,12 +152,31 @@ pub unsafe trait AudioExt {
 pub unsafe trait LoadExt {
     /// Load audio from a file
     fn load<P: AsRef<Path>>(&mut self, path: P) -> Result<(), SoloudError>;
-    /// Load audio from memory
-    fn load_mem(&mut self, data: &[u8]) -> Result<(), SoloudError>;
-    /// Load audio from memory with options to copy and/or take ownership
+    /// Load audio from memory. Prefer `load_mem_weak` when possible like when using
+    /// `'static &[u8]`
+    fn load_mem<'a>(&mut self, data: impl Into<Cow<'a, [u8]>>) -> Result<(), SoloudError> {
+        // take the ownership of the data or clone
+        let data = data.into().into_owned();
+        let res = unsafe { self._load_mem_ex(&data, false, true) };
+        // move the ownership to SoLoud
+        std::mem::forget(data);
+        res
+    }
+    /// Load audio from memory. The data will be weakly referenced by SoLoud
+    fn load_mem_weak<'a, 'b: 'a>(&'a mut self, data: &'b [u8]) -> Result<(), SoloudError> {
+        unsafe { self._load_mem_ex(data, false, false) }
+    }
+    /// Load audio from memory. The data will be weakly referenced by SoLoud without any lifetime
+    /// validation
+    /// # Safety
+    /// The audio source must not be invalidated
+    unsafe fn load_mem_weak_unsafe(&mut self, data: &[u8]) -> Result<(), SoloudError> {
+        self._load_mem_ex(data, false, false)
+    }
+    /// (Internal) load audio from memory with options to copy and/or take ownership
     /// # Safety
     /// The audio source should not be invalidated
-    unsafe fn load_mem_ex(
+    unsafe fn _load_mem_ex(
         &mut self,
         data: &[u8],
         copy: bool,
@@ -189,10 +209,16 @@ pub trait FilterAttr {
 }
 
 pub unsafe trait FromExt: Sized {
-    /// Helper methods for loading an audio source from a path
+    /// Loads an audio source from path
     fn from_path<P: AsRef<Path>>(p: P) -> Result<Self, SoloudError>;
-    /// Helper methods for loading an audio source from memory
-    fn from_mem(data: &[u8]) -> Result<Self, SoloudError>;
+    /// Loads an audio source from memory. Prefer [`LoadExt::load_mem`] when possible like when
+    /// using `'static &[u8]`
+    fn from_mem<'a>(data: impl Into<Cow<'a, [u8]>>) -> Result<Self, SoloudError>;
+    /// Load audio from memory. The data will be weakly referenced by SoLoud without any lifetime
+    /// validation
+    /// # Safety
+    /// The audio source must not be invalidated
+    unsafe fn from_mem_weak_unsafe(data: &[u8]) -> Result<Self, SoloudError>;
 }
 
 unsafe impl<T: AudioExt + LoadExt> FromExt for T {
@@ -202,9 +228,15 @@ unsafe impl<T: AudioExt + LoadExt> FromExt for T {
         Ok(x)
     }
 
-    fn from_mem(data: &[u8]) -> Result<Self, SoloudError> {
+    fn from_mem<'a>(data: impl Into<Cow<'a, [u8]>>) -> Result<Self, SoloudError> {
         let mut x = Self::default();
         x.load_mem(data)?;
+        Ok(x)
+    }
+
+    unsafe fn from_mem_weak_unsafe(data: &[u8]) -> Result<Self, SoloudError> {
+        let mut x = Self::default();
+        x.load_mem_weak_unsafe(data)?;
         Ok(x)
     }
 }


### PR DESCRIPTION
Fixes #9. Now my game runs without crashing!

* Breaking change: `load_mem_ex` is renamed to `_load_mem_ex`.

As always, please modify any details as you like.

Also, adding short module comment before updating to 0.3.1 would be nice. I tried writing some:

```rust
 /* audio/mod.rs */
//! Audio sources

 /* filter/mod.rs */
//! Audio filters

 /* lib.rs:struct Handle */
/// `Handle` can be used to adjust the parameters of the sound while it's playing
```

Not sure if they're appropriate comments, but maybe better than nothing?

Thank you :) [Edited]