### PR TITLE
No `Cow`

### DIFF
--- a/soloud/src/audio/mod.rs
+++ b/soloud/src/audio/mod.rs
@@ -1,5 +1,3 @@
-//! Audio sources
-
 mod ay;
 mod bus;
 mod monotone;

--- a/soloud/src/filter/mod.rs
+++ b/soloud/src/filter/mod.rs
@@ -1,5 +1,3 @@
-//! Audio filters
-
 mod bass;
 mod biquad;
 mod dc;

--- a/soloud/src/lib.rs
+++ b/soloud/src/lib.rs
@@ -176,6 +176,9 @@ use soloud_sys::soloud as ffi;
 pub struct Handle(u32);
 
 impl Handle {
+    /// Primary bus
+    pub const PRIMARY: Self = Self(0);
+
     /// Create a handle from a raw value
     /// # Safety
     /// The value must be a valid handle
@@ -493,9 +496,9 @@ impl Soloud {
     }
 
     /// Play in the background
-    pub fn play_background<AS: AudioExt>(&self, sound: &AS) -> u32 {
+    pub fn play_background<AS: AudioExt>(&self, sound: &AS) -> Handle {
         assert!(!self._inner.is_null());
-        unsafe { ffi::Soloud_playBackground(self._inner, sound.inner()) }
+        Handle(unsafe { ffi::Soloud_playBackground(self._inner, sound.inner()) })
     }
 
     /// Play in the background with extra args

--- a/soloud/src/lib.rs
+++ b/soloud/src/lib.rs
@@ -154,7 +154,7 @@ macro_rules! ffi_call {
 pub mod audio;
 /// Filter module containing all filter types and attributes
 pub mod filter;
-/// prelude module containing all traits and error codes
+/// Prelude module containing all traits and error codes
 pub mod prelude;
 // pub mod effects;
 
@@ -170,8 +170,8 @@ pub use prelude::*;
 
 use soloud_sys::soloud as ffi;
 
-/// A wrapper around the raw handle of the audio object  
-/// which can be used to adjust the parameters of the sound while it's playing
+/// A wrapper around the raw handle of the audio object which can be used to adjust the parameters
+/// of the sound while it's playing
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Handle(u32);
 
@@ -196,36 +196,36 @@ impl Handle {
 #[repr(u32)]
 #[derive(Debug, Clone, Copy)]
 pub enum Backend {
-/// Autoselection by Soloud
-Auto = 0,
-/// Sdl2
-Sdl2 = 2,
-/// Portaudio
-Portaudio = 3,
-/// Winmm
-Winmm = 4,
-/// Xaudio2
-Xaudio2 = 5,
-/// Wasapi
-Wasapi = 6,
-/// Alsa
-Alsa = 7,
-/// Jack
-Jack = 8,
-/// Oss
-Oss = 9,
-/// OpenAL
-OpenAL = 10,
-/// Coreaudio
-CoreAudio = 11,
-/// OpenSLES
-OpenSLES = 12,
-/// Miniaudio
-Miniaudio = 14,
-/// Nosound
-Nosound = 15,
-/// Null driver
-Null = 16,
+    /// Autoselection by Soloud
+    Auto = 0,
+    /// Sdl2
+    Sdl2 = 2,
+    /// Portaudio
+    Portaudio = 3,
+    /// Winmm
+    Winmm = 4,
+    /// Xaudio2
+    Xaudio2 = 5,
+    /// Wasapi
+    Wasapi = 6,
+    /// Alsa
+    Alsa = 7,
+    /// Jack
+    Jack = 8,
+    /// Oss
+    Oss = 9,
+    /// OpenAL
+    OpenAL = 10,
+    /// Coreaudio
+    CoreAudio = 11,
+    /// OpenSLES
+    OpenSLES = 12,
+    /// Miniaudio
+    Miniaudio = 14,
+    /// Nosound
+    Nosound = 15,
+    /// Null driver
+    Null = 16,
 }
 
 /// Wrapper around the Soloud native object

--- a/soloud/src/prelude.rs
+++ b/soloud/src/prelude.rs
@@ -1,5 +1,4 @@
 // pub use crate::effects::*;
-use std::borrow::Cow;
 use std::convert::From;
 use std::os::raw::*;
 use std::path::Path;
@@ -190,9 +189,7 @@ pub unsafe trait LoadExt {
     fn load<P: AsRef<Path>>(&mut self, path: P) -> Result<(), SoloudError>;
     /// Load audio from memory. Prefer `load_mem_weak` when possible like when using
     /// `'static &[u8]`
-    fn load_mem<'a>(&mut self, data: impl Into<Cow<'a, [u8]>>) -> Result<(), SoloudError> {
-        // take the ownership of the data or clone
-        let data = data.into().into_owned();
+    fn load_mem(&mut self, data: Vec<u8>) -> Result<(), SoloudError> {
         let res = unsafe { self._load_mem_ex(&data, false, true) };
         // move the ownership to SoLoud
         std::mem::forget(data);
@@ -252,7 +249,7 @@ pub unsafe trait FromExt: Sized {
     fn from_path<P: AsRef<Path>>(p: P) -> Result<Self, SoloudError>;
     /// Loads an audio source from memory. Prefer [`LoadExt::load_mem`] when possible like when
     /// using `'static &[u8]`
-    fn from_mem<'a>(data: impl Into<Cow<'a, [u8]>>) -> Result<Self, SoloudError>;
+    fn from_mem<'a>(data: Vec<u8>) -> Result<Self, SoloudError>;
     /// Load audio from memory. The data will be weakly referenced by SoLoud without any lifetime
     /// validation
     /// # Safety
@@ -267,7 +264,7 @@ unsafe impl<T: AudioExt + LoadExt> FromExt for T {
         Ok(x)
     }
 
-    fn from_mem<'a>(data: impl Into<Cow<'a, [u8]>>) -> Result<Self, SoloudError> {
+    fn from_mem<'a>(data: Vec<u8>) -> Result<Self, SoloudError> {
         let mut x = Self::default();
         x.load_mem(data)?;
         Ok(x)


### PR DESCRIPTION
Hi :)

I made 3 Commits:

1. Use of `Cow` was a mistake. User should make explicit `clone` call on sound data bytes
2. `Handle` fixes
2-1. Added `Handle::PRIMARY`. As in [soloud doc](https://sol.gfxile.net/soloud/basics.html), `0` handle represents "primary bus" (I'm not sure what is is..)
2-2. `Soloud::play_background` should return `Handle`
3. Removed duplicate docstrings and ran `cargo fmt`