### PR TITLE
remove extraneous exclamation marks from URL's

### DIFF
--- a/soloud/src/lib.rs
+++ b/soloud/src/lib.rs
@@ -5,8 +5,8 @@
 //! Supported formats: wav, mp3, ogg. The library also comes with a speech synthesizer.
 //!
 //!
-//! - The official soloud [website](https://!sol.gfxile.net/soloud/index.html)
-//! - The official soloud [repo](https://!github.com/jarikomppa/soloud)
+//! - The official soloud [website](https://sol.gfxile.net/soloud/index.html)
+//! - The official soloud [repo](https://github.com/jarikomppa/soloud)
 //!
 //! ## Usage
 //! ```toml


### PR DESCRIPTION
Hi,

These url's are broken on the Rust docs website:

https://docs.rs/soloud/0.4.0/soloud/

Thanks!