### PR TITLE
more fix to `load_mem` and `from_mem`

### DIFF
--- a/soloud/examples/include_bytes.rs
+++ b/soloud/examples/include_bytes.rs
@@ -5,7 +5,7 @@ fn main() {
     // use soloud::*;
     // let sl = Soloud::default().unwrap();
     // let mut wav = audio::Wav::default();
-    // // Use weak reference because we know `'static &[u8]` lives longer than `Soloud`
+    // // Use weak reference because we know `&'static [u8]` lives longer than `Soloud`
     // wav.load_mem_weak(include_bytes!("../audio.mp3")).unwrap();
     // sl.play(&wav);
     // while sl.voice_count() > 0 {

--- a/soloud/examples/load_mem.rs
+++ b/soloud/examples/load_mem.rs
@@ -5,9 +5,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut wav = audio::Wav::default();
 
-    let bytes = std::fs::read("sample.wav")?;
-
-    wav.load_mem(bytes)?;
+    {
+        let bytes = std::fs::read("sample.wav")?;
+        wav.load_mem(&bytes)?;
+    }
 
     sl.play(&wav);
     while sl.voice_count() > 0 {

--- a/soloud/src/prelude.rs
+++ b/soloud/src/prelude.rs
@@ -188,11 +188,9 @@ pub unsafe trait LoadExt {
     /// Load audio from a file
     fn load<P: AsRef<Path>>(&mut self, path: P) -> Result<(), SoloudError>;
     /// Load audio from memory. Prefer `load_mem_weak` when possible like when using
-    /// `'static &[u8]`
-    fn load_mem(&mut self, data: Vec<u8>) -> Result<(), SoloudError> {
-        let res = unsafe { self._load_mem_ex(&data, true, false) };
-        // move the ownership to SoLoud
-        res
+    /// `&'static [u8]`
+    fn load_mem(&mut self, data: &[u8]) -> Result<(), SoloudError> {
+        unsafe { self._load_mem_ex(&data, true, false) }
     }
     /// Load audio from memory. The data will be weakly referenced by SoLoud
     fn load_mem_weak<'a, 'b: 'a>(&'a mut self, data: &'b [u8]) -> Result<(), SoloudError> {
@@ -247,8 +245,8 @@ pub unsafe trait FromExt: Sized {
     /// Loads an audio source from path
     fn from_path<P: AsRef<Path>>(p: P) -> Result<Self, SoloudError>;
     /// Loads an audio source from memory. Prefer [`LoadExt::load_mem`] when possible like when
-    /// using `'static &[u8]`
-    fn from_mem<'a>(data: Vec<u8>) -> Result<Self, SoloudError>;
+    /// using `&'static [u8]`
+    fn from_mem<'a>(data: &[u8]) -> Result<Self, SoloudError>;
     /// Load audio from memory. The data will be weakly referenced by SoLoud without any lifetime
     /// validation
     /// # Safety
@@ -263,7 +261,7 @@ unsafe impl<T: AudioExt + LoadExt> FromExt for T {
         Ok(x)
     }
 
-    fn from_mem<'a>(data: Vec<u8>) -> Result<Self, SoloudError> {
+    fn from_mem<'a>(data: &[u8]) -> Result<Self, SoloudError> {
         let mut x = Self::default();
         x.load_mem(data)?;
         Ok(x)


### PR DESCRIPTION
Now that SoLoud copies sound data bytes, it makes sense to use `&[u8]` as type parameter.