### PR TITLE
new function: audio::Wav::default_with_load

### DIFF
--- a/soloud/src/audio/wav.rs
+++ b/soloud/src/audio/wav.rs
@@ -12,6 +12,35 @@ crate::macros::load::impl_load_ext!(Wav);
 crate::macros::audio::impl_audio_ext!(Wav);
 
 impl Wav {
+    /// Create immutable Wav instance with already loaded music
+    ///
+    /// # Examples
+    ///
+    /// use soloud::*;
+    /// 
+    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let sl = Soloud::default()?;
+    ///
+    ///     let wav = audio::Wav::default_with_load("sample.wav")?;
+    ///
+    ///     sl.play(&wav);
+    ///     while sl.voice_count() > 0 {
+    ///         std::thread::sleep(std::time::Duration::from_millis(100));
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    /// 
+    pub fn default_with_load<P: AsRef<Path>>(path: P) -> Result<Self, SoloudError> {
+        let ptr = unsafe { ffi::Wav_create() };
+        assert!(!ptr.is_null());
+        let mut wav = Wav { inner: ptr };
+        match wav.load(path) {
+            Ok(_)    => Ok(wav),
+            Err(err) => Err(err)
+        }
+    }
+
     /// Load raw wav data of precise bits
     /// # Safety
     /// The data must be valid

--- a/soloud/src/audio/wav.rs
+++ b/soloud/src/audio/wav.rs
@@ -15,7 +15,7 @@ impl Wav {
     /// Create immutable Wav instance with already loaded music
     ///
     /// # Examples
-    ///
+    /// ```
     /// use soloud::*;
     /// 
     /// fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -30,7 +30,8 @@ impl Wav {
     ///
     ///     Ok(())
     /// }
-    /// 
+    /// ```
+    ///
     pub fn default_with_load<P: AsRef<Path>>(path: P) -> Result<Self, SoloudError> {
         let ptr = unsafe { ffi::Wav_create() };
         assert!(!ptr.is_null());


### PR DESCRIPTION
I think it's convenient to have function like audio::Wav::default_with_load, otherwise you'd have to create mutable instance and then load file, with the default_with_load you can have immutable Wav instance with already loaded music file, this's especially convenient when you only need to play one music and don't need to load another one.