### PR TITLE
Building SoLoud with the same profile cargo uses

### DIFF
--- a/soloud-sys/build/source.rs
+++ b/soloud-sys/build/source.rs
@@ -57,8 +57,14 @@ pub fn build(target_triple: &str, out_dir: &Path) {
             dst.define("CMAKE_TOOLCHAIN_FILE", &toolchain);
         }
 
+        let profile = match std::env::var("PROFILE").unwrap().as_str() {
+            "debug" => "Debug",
+            "release" => "Release",
+            _ => "Release",
+        };
+
         let _dst = dst
-            .profile("Debug")
+            .profile(profile)
             .define("CMAKE_EXPORT_COMPILE_COMMANDS", "ON")
             .build();
     }


### PR DESCRIPTION
This prevents VCRUNTIME140D.dll getting linked instead of VCRUNTIME140.dll in release builds.

Users of built software mostly only have VC++ Redist installed, not the developer stuff via VS.